### PR TITLE
Set debug level at CLI

### DIFF
--- a/snow-control/control.py
+++ b/snow-control/control.py
@@ -45,7 +45,7 @@ def interactive():
         print(f'PASSWORD is blank, starting SSO auth for user {user}')
     
     conn = initialize_connection(account_name = account, username = user, password = password)
-    state = ControlState()
+    state = ControlState(verbosity_level = 3)
     state.account, state.connection = account, conn
     state.ignore_objects = get_ignored_object_patterns(state.account)
     

--- a/snow-control/control.py
+++ b/snow-control/control.py
@@ -109,6 +109,13 @@ def menu_screen(st:ControlState) -> bool:
 
     if response == 'clear':
         clear_cache(st.account)
+    elif response == 'debug':
+        if params and params[0].isnumeric(): 
+            debug_level = int(params[0])
+            print(f'Setting verbosity level: {debug_level}')
+            st.verbosity = debug_level
+        else:
+            print(f'Improper verbosity level : {debug_level}')
     elif response == 'get':
         print('\n')
         st.print(f'Getting latest list of objects in account {Style.BRIGHT + Fore.YELLOW}{st.account}')

--- a/snow-control/control.py
+++ b/snow-control/control.py
@@ -45,7 +45,7 @@ def interactive():
         print(f'PASSWORD is blank, starting SSO auth for user {user}')
     
     conn = initialize_connection(account_name = account, username = user, password = password)
-    state = ControlState(verbosity_level = 3)
+    state = ControlState(verbosity = 3)
     state.account, state.connection = account, conn
     state.ignore_objects = get_ignored_object_patterns(state.account)
     

--- a/snow-control/control_state.py
+++ b/snow-control/control_state.py
@@ -12,7 +12,7 @@ class ControlState:
         self.executor.shutdown()
     
     def print(self,message,  verbosity_level = 0, **kwargs):
-        if verbosity_level >= self.verbosity:
+        if verbosity_level <= self.verbosity:
             print(message, **kwargs)
 
     

--- a/snow-control/control_state.py
+++ b/snow-control/control_state.py
@@ -33,21 +33,21 @@ class ControlState:
         for recipient, config in plan.items(): 
             # NO DELTAS
             if not config['to_revoke'] and not config['to_grant']: 
-                self.print(f'{Style.BRIGHT + Fore.YELLOW}{grants_to}: {recipient}',verbosity_level=2)
+                self.print(f'{Style.BRIGHT + Fore.YELLOW}{grants_to}: {recipient}',verbosity_level=2, end = '\t\t')
                 self.print(f'{Style.BRIGHT + Fore.CYAN}ALL_GOOD!:({len(config["ok"])}:0) {TABLE_FLIP}', verbosity_level=2, end = '\n\n')
             else:
                 self.print(f'{Style.BRIGHT + Fore.YELLOW}{grants_to}: {recipient}')
 
-            if config['to_revoke'] or self.verbosity >= 3: 
-                self.print(f'{Style.BRIGHT+Fore.CYAN}PRIVILEGES TO BE {Style.BRIGHT + Fore.RED}REVOKED:', end = '\n\n')
-                for minus in sorted(config['to_revoke'], key = lambda x: x[1] + x[2] + x[0]): 
-                    self.print(Fore.RED + format_privilege(*minus, delta = '-'))
-                self.print('\n')
-            if config['to_grant'] or self.verbosity >=3: 
-                self.print(f'{Style.BRIGHT+Fore.CYAN}PRIVILEGES TO BE {Style.BRIGHT + Fore.GREEN}GRANTED:', end = '\n\n')
-                for minus in sorted(config['to_grant'], key = lambda x: x[1] + x[2] + x[0]): 
-                    self.print(Fore.GREEN + format_privilege(*minus, delta = '-'))
-                self.print('\n')
+                if config['to_revoke'] or self.verbosity >= 3: 
+                    self.print(f'{Style.BRIGHT+Fore.CYAN}PRIVILEGES TO BE {Style.BRIGHT + Fore.RED}REVOKED:', end = '\n\n')
+                    for minus in sorted(config['to_revoke'], key = lambda x: x[1] + x[2] + x[0]): 
+                        self.print(Fore.RED + format_privilege(*minus, delta = '-'))
+                    self.print('\n')
+                if config['to_grant'] or self.verbosity >=3: 
+                    self.print(f'{Style.BRIGHT+Fore.CYAN}PRIVILEGES TO BE {Style.BRIGHT + Fore.GREEN}GRANTED:', end = '\n\n')
+                    for minus in sorted(config['to_grant'], key = lambda x: x[1] + x[2] + x[0]): 
+                        self.print(Fore.GREEN + format_privilege(*minus, delta = '-'))
+                    self.print('\n')
 
             GRANT_SUMMARY_VERBOSITY = 4
             self.print(f'{Style.BRIGHT}Grant Deltas: {recipient}', verbosity_level = GRANT_SUMMARY_VERBOSITY )

--- a/snow-control/control_state.py
+++ b/snow-control/control_state.py
@@ -17,14 +17,26 @@ class ControlState:
 
     
     def print_formatted_plan(self, plan:dict, grants_to = 'ROLE') -> None: 
+        """
+            Print out the formatted plan with the following information: 
+            NO DELTAS: 
+                Verbosity 0,1 Print Nothing 
+                Verbosity 2,3: Print "all good"
+                Verbosity 4+: Print "grant deltas" summary
+            DELTAS:
+                Verbosity 0,1,2: Print only the categories that have deltas
+                Verbosity 3: Print empty space for categories that have no delta
+                Verbosity 4+: Print "grant deltas" summary 
+        """
         TABLE_FLIP = '(╯°□°)╯︵ ┻━┻'
         self.print('\n'*4)
         for recipient, config in plan.items(): 
-            # SKIP if all good!
+            # NO DELTAS
             if not config['to_revoke'] and not config['to_grant']: 
-                self.print(f'{Style.BRIGHT + Fore.YELLOW}{grants_to}: {recipient}',verbosity_level=3)
-                self.print(f'{Style.BRIGHT + Fore.CYAN}ALL_GOOD!:({len(config["ok"])}:0) {TABLE_FLIP}', verbosity_level=3, end = '\n\n')
-            self.print(f'{Style.BRIGHT + Fore.YELLOW}{grants_to}: {recipient}')
+                self.print(f'{Style.BRIGHT + Fore.YELLOW}{grants_to}: {recipient}',verbosity_level=2)
+                self.print(f'{Style.BRIGHT + Fore.CYAN}ALL_GOOD!:({len(config["ok"])}:0) {TABLE_FLIP}', verbosity_level=2, end = '\n\n')
+            else:
+                self.print(f'{Style.BRIGHT + Fore.YELLOW}{grants_to}: {recipient}')
 
             if config['to_revoke'] or self.verbosity >= 3: 
                 self.print(f'{Style.BRIGHT+Fore.CYAN}PRIVILEGES TO BE {Style.BRIGHT + Fore.RED}REVOKED:', end = '\n\n')
@@ -36,9 +48,11 @@ class ControlState:
                 for minus in sorted(config['to_grant'], key = lambda x: x[1] + x[2] + x[0]): 
                     self.print(Fore.GREEN + format_privilege(*minus, delta = '-'))
                 self.print('\n')
-            self.print(f'{Style.BRIGHT}Grant Deltas: {recipient}', verbosity_level= 2 )
-            self.print(f'{Style.BRIGHT+Fore.RED}- {len(config["to_revoke"])}', verbosity_level= 2)
-            self.print(f'{Style.BRIGHT+Fore.CYAN}= {len(config["ok"])}', verbosity_level= 2)
-            self.print(f'{Style.BRIGHT+Fore.GREEN}+ {len(config["to_grant"])}', verbosity_level= 2)
-            self.print('==================', verbosity_level= 2)
-            self.print(f'{Style.BRIGHT}T {len(config["to_revoke"]) + len(config["ok"]) + len(config["to_grant"])}', verbosity_level= 2)
+
+            GRANT_SUMMARY_VERBOSITY = 4
+            self.print(f'{Style.BRIGHT}Grant Deltas: {recipient}', verbosity_level = GRANT_SUMMARY_VERBOSITY )
+            self.print(f'{Style.BRIGHT+Fore.RED}- {len(config["to_revoke"])}', verbosity_level = GRANT_SUMMARY_VERBOSITY)
+            self.print(f'{Style.BRIGHT+Fore.CYAN}= {len(config["ok"])}', verbosity_level = GRANT_SUMMARY_VERBOSITY)
+            self.print(f'{Style.BRIGHT+Fore.GREEN}+ {len(config["to_grant"])}', verbosity_level = GRANT_SUMMARY_VERBOSITY)
+            self.print('==================', verbosity_level = GRANT_SUMMARY_VERBOSITY)
+            self.print(f'{Style.BRIGHT}T {len(config["to_revoke"]) + len(config["ok"]) + len(config["to_grant"])}', verbosity_level = GRANT_SUMMARY_VERBOSITY)

--- a/snow-control/control_state.py
+++ b/snow-control/control_state.py
@@ -25,8 +25,8 @@ class ControlState:
                 Verbosity 3: Print "all good"
                 Verbosity 4+: Print "grant deltas" summary
             DELTAS:
-                Verbosity 0,1,2: Print only the categories that have deltas
-                Verbosity 3: Print empty space for categories that have no delta
+                Verbosity 0: Print only the categories that have deltas
+                Verbosity 1,2,3: Print empty space for categories that have no delta
                 Verbosity 4+: Print "grant deltas" summary 
         """
         TABLE_FLIP = '(╯°□°)╯︵ ┻━┻'
@@ -34,18 +34,18 @@ class ControlState:
         for recipient, config in plan.items(): 
             # NO DELTAS
             if not config['to_revoke'] and not config['to_grant']: 
-                self.print(f'{Style.BRIGHT + Fore.YELLOW}{grants_to}: {recipient} \t {GREEN_CHECKMARK}',verbosity_level=2,)
+                self.print(f'{Style.BRIGHT + Fore.YELLOW}{grants_to}: {recipient} \t {GREEN_CHECKMARK}',verbosity_level=2)
                 self.print(f'{Style.BRIGHT + Fore.CYAN}ALL_GOOD!:({len(config["ok"])}:0) {TABLE_FLIP}', verbosity_level=3, end = '\n')
             else:
                 print('\n')
                 self.print(f'{Style.BRIGHT + Fore.YELLOW}{grants_to}: {recipient}')
 
-                if config['to_revoke'] or self.verbosity >= 3: 
+                if config['to_revoke'] or self.verbosity >= 1: 
                     self.print(f'{Style.BRIGHT+Fore.CYAN}PRIVILEGES TO BE {Style.BRIGHT + Fore.RED}REVOKED:', end = '\n\n')
                     for minus in sorted(config['to_revoke'], key = lambda x: x[1] + x[2] + x[0]): 
                         self.print(Fore.RED + format_privilege(*minus, delta = '-'))
                     self.print('\n')
-                if config['to_grant'] or self.verbosity >=3: 
+                if config['to_grant'] or self.verbosity >=1: 
                     self.print(f'{Style.BRIGHT+Fore.CYAN}PRIVILEGES TO BE {Style.BRIGHT + Fore.GREEN}GRANTED:', end = '\n\n')
                     for minus in sorted(config['to_grant'], key = lambda x: x[1] + x[2] + x[0]): 
                         self.print(Fore.GREEN + format_privilege(*minus, delta = '-'))

--- a/snow-control/control_state.py
+++ b/snow-control/control_state.py
@@ -21,7 +21,8 @@ class ControlState:
             Print out the formatted plan with the following information: 
             NO DELTAS: 
                 Verbosity 0,1 Print Nothing 
-                Verbosity 2,3: Print "all good"
+                Verbosity 2: Print checkmark
+                Verbosity 3: Print "all good"
                 Verbosity 4+: Print "grant deltas" summary
             DELTAS:
                 Verbosity 0,1,2: Print only the categories that have deltas
@@ -33,9 +34,10 @@ class ControlState:
         for recipient, config in plan.items(): 
             # NO DELTAS
             if not config['to_revoke'] and not config['to_grant']: 
-                self.print(f'{Style.BRIGHT + Fore.YELLOW}{grants_to}: {recipient}',verbosity_level=2, end = '\t\t')
-                self.print(f'{Style.BRIGHT + Fore.CYAN}ALL_GOOD!:({len(config["ok"])}:0) {TABLE_FLIP}', verbosity_level=2, end = '\n\n')
+                self.print(f'{Style.BRIGHT + Fore.YELLOW}{grants_to}: {recipient} \t {GREEN_CHECKMARK}',verbosity_level=2,)
+                self.print(f'{Style.BRIGHT + Fore.CYAN}ALL_GOOD!:({len(config["ok"])}:0) {TABLE_FLIP}', verbosity_level=3, end = '\n')
             else:
+                print('\n')
                 self.print(f'{Style.BRIGHT + Fore.YELLOW}{grants_to}: {recipient}')
 
                 if config['to_revoke'] or self.verbosity >= 3: 

--- a/snow-control/control_state.py
+++ b/snow-control/control_state.py
@@ -4,9 +4,9 @@ from styling import *
 
 class ControlState:
     __slots__ = 'connection', 'account', 'executor','snowcache','snowplan','queries','ignore_objects','verbosity'
-    def __init__(self, max_workers = 100):
+    def __init__(self, verbosity = 3, max_workers = 100):
         self.executor = ThreadPoolExecutor(max_workers=max_workers)
-        self.verbosity = 0 
+        self.verbosity = verbosity
 
     def __del__(self): 
         self.executor.shutdown()

--- a/snow-control/plan.py
+++ b/snow-control/plan.py
@@ -164,9 +164,11 @@ def gen_acct_level_grants(account_privilege_profile:dict) -> str:
 
 def get_current_grants_to_role(state,role):
     cur = state.connection.cursor()
+    state.print(f'Executing show query on role {role}', verbosity_level = 4)
     cur.execute(f'show grants to role {role}')
     qid = cur.sfqid
-
+    
+    state.print(f'Retrieving current grants to role {role}', verbosity_level = 3)
     results = set(list(cur.execute(
         CURRENT_GRANTS_TO_ROLE.format(qid = qid)
     )))
@@ -183,9 +185,11 @@ def get_current_grants_to_role(state,role):
 
 def get_future_grants_to_role(state,role):
     cur = state.connection.cursor()
+    state.print(f'Executing show future query on role {role}', verbosity_level = 4)
     cur.execute(f'show future grants to role {role}')
     qid = cur.sfqid
 
+    state.print(f'Retrieving future grants to role {role}', verbosity_level = 3)
     results = set(list(cur.execute(
         FUTURE_GRANTS_TO_ROLE.format(qid = qid)
     )))
@@ -211,9 +215,11 @@ def venn(set1:set, set2:set) -> Tuple[set,set,set]:
 
 def get_current_users_roles(state:ControlState,user:str)-> set:
     cur = state.connection.cursor()
+    state.print(f'Executing show query on user {user}', verbosity_level = 4)
     query = GRANTS_TO_USER_QUERY.format(user=user)
     cur.execute(query)
     qid = cur.sfqid
+    state.print(f'Retrieving current grants to user {user}', verbosity_level = 3)
     roles_granted = set(x for x, in cur.execute(RETRIEVE_GRANTS_TO_USER_QUERY.format(qid =qid)).fetchall())
     return roles_granted
 

--- a/snow-control/plan.py
+++ b/snow-control/plan.py
@@ -117,7 +117,7 @@ def profile_to_grants(state:ControlState,all_objects:dict,profile_name:str, prof
         ) to a list of atomic privileges
     """
     param_string = [f'{k}={repr(v)}' for k,v in requires.items()]
-    state.print(f"Beginning conversion of profile {profile_name}({','.join(param_string)})")
+    state.print(f"Beginning conversion of profile {profile_name}({','.join(param_string)})", verbosity_level=5)
     grants = []
     future_grants = []
     for object_type, object_privs in profile['privileges'].items():


### PR DESCRIPTION
Snow Control is a complicated beast, and you may experience slowdowns, errors, or confusing behavior at any given point in time. On the other hand, you might breeze through the experience, because you are only executing 3 or 4 sql queries.  With the former, it is important that you have detailed play-by-play logging so you can identify potential issues, hangups, slowdowns, etc.  With the latter, you would want a clean interface with minimal clutter. 

To this end, it is important to have a debug_level or verbosity_level that you can CHANGE mid-execution at the CLI level. 
This feature serves to do exactly that.  While the exact numbers of the debug_level may change overtime the idea is that you can set a custom level 0-5 that will print debug logs of varying verbosity to the terminal during code execution. 

0 - minimal logging necessary for execution. 
1 - minimal logging, plans and other traditionally shown artefacts might show additional information only on entities that might be changed by plan execution to emphasize confidence 
2 -minimal logging, plans and other traditionally shown artefacts will provide some detail on all entities to see the configuration of all resources in account, including those not planned to change under Snow Control. 
3 - basic logging - enough to see and follow the trace of the code execution pathways. Useful as a first step to identify potential slowdowns or bottlenecks in code. Plans will have more detail on all entities as well 
4 - detailed logging - at a query level or deeper . Useful to track all external function calls for get, plan, and apply. Plans will provided detailed information on all objects and both the proposed changes and existing configuration

5 - extremely detailed logging - should be rarely used by users. Useful primarily for other developers of this tool to identify potential improvements, rearchitectures, new features, workarounds, etc. 

6 - run... just run....